### PR TITLE
Manpage update and test optimalisation (as proposed)

### DIFF
--- a/man/man8/zfsprops.8
+++ b/man/man8/zfsprops.8
@@ -713,7 +713,8 @@ for more information on these algorithms.
 Changing this property affects only newly-written data.
 .It Xo
 .Sy compression Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Sy gzip Ns | Ns
-.Sy gzip- Ns Em N Ns | Ns Sy lz4 Ns | Ns Sy lzjb Ns | Ns Sy zle
+.Sy gzip- Ns Em N Ns | Ns Sy lz4 Ns | Ns Sy lzjb Ns | Ns Sy zle Ns | Ns Sy zstd Ns | Ns
+.Sy zstd- Ns Em N Ns | Ns Sy zstd-fast- Ns Em N
 .Xc
 Controls the compression algorithm used for this dataset.
 .Pp
@@ -778,6 +779,35 @@ is equivalent to
 .Sy gzip-6
 .Po which is also the default for
 .Xr gzip 1
+.Pc .
+.Pp
+The
+.Sy zstd
+compression using the zstd algorithm ,
+You can specify the
+.Sy zstd
+level by using the value
+.Sy zstd- Ns Em N ,
+where
+.Em N
+is an integer from 1
+.Pq fastest
+to 19
+.Pq best compression ratio .
+.Sy zstd
+You can also specify a negative 
+.Sy zstd
+level by using the value
+.Sy zstd- Ns Em N ,
+where
+.Em N
+is an integer from 100
+.Pq fastest
+to 1
+.Pq best compression ratio .
+.Sy zstd
+is equivalent to
+.Sy zstd-3
 .Pc .
 .Pp
 The

--- a/tests/zfs-tests/include/properties.shlib
+++ b/tests/zfs-tests/include/properties.shlib
@@ -13,7 +13,7 @@
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 #
 
-typeset -a compress_prop_vals=('on' 'off' 'lzjb' 'gzip' 'zle' 'lz4' 'zstd')
+typeset -a compress_prop_vals=('off' 'lzjb' 'gzip' 'zle' 'lz4' 'zstd')
 typeset -a checksum_prop_vals=('on' 'off' 'fletcher2' 'fletcher4' 'sha256'
     'noparity' 'sha512' 'skein' 'edonr')
 typeset -a recsize_prop_vals=('512' '1024' '2048' '4096' '8192' '16384'

--- a/tests/zfs-tests/tests/functional/rsend/rsend_012_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_012_pos.ksh
@@ -121,7 +121,7 @@ for fs in "$POOL" "$POOL/pclone" "$POOL/$FS" "$POOL/$FS/fs1" \
 	rand_set_prop $fs acltype "off" "noacl" "posixacl"
 	rand_set_prop $fs atime "on" "off"
 	rand_set_prop $fs checksum "on" "off" "fletcher2" "fletcher4" "sha256"
-	rand_set_prop $fs compression "on" "off" "lzjb" "gzip" "lz4" "zle" "zstd"
+	rand_set_prop $fs compression "off" "lzjb" "gzip" "lz4" "zle" "zstd"
 	rand_set_prop $fs copies "1" "2" "3"
 	rand_set_prop $fs devices "on" "off"
 	rand_set_prop $fs exec "on" "off"

--- a/tests/zfs-tests/tests/functional/rsend/send-c_lz4_disabled.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_lz4_disabled.ksh
@@ -47,7 +47,7 @@ log_onexit cleanup
 datasetexists $POOL2 && log_must zpool destroy $POOL2
 log_must zpool create -d $POOL2 $DISK2
 
-for compress in off gzip; do
+for compress in off gzip zstd; do
 	for pool_opt in '' -d; do
 		poolexists $POOL3 && destroy_pool $POOL3
 		log_must zpool create $pool_opt $POOL3 $DISK3

--- a/tests/zfs-tests/tests/functional/rsend/send-c_verify_ratio.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send-c_verify_ratio.ksh
@@ -37,7 +37,7 @@ log_onexit cleanup_pool $POOL2
 typeset sendfs=$POOL2/$FS
 typeset megs=128
 
-for prop in $(get_rand_compress_any 6); do
+for prop in 'off' 'lzjb' 'gzip' 'zle' 'lz4' 'zstd'; do
 	for compressible in 'yes' 'no'; do
 		log_must zfs create -o compress=$prop $sendfs
 


### PR DESCRIPTION
This PR implements the manpage and test changes I requested.
Instead of being lazy I did them myself.

I'm not really sure about the manpage, would be nice if you can check that one, rest should be pretty sollid!

- Add zstd and zstd-fast to zfsprops.8 manpage
- removes "on" from compression test (lz4 duplicate)
- changes send-verify-ratio to non-random compression

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>
