### PR TITLE
Adding zstd to history_002_pos.ksh

### DIFF
--- a/tests/zfs-tests/tests/functional/history/history_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_002_pos.ksh
@@ -86,7 +86,9 @@ props=(
 	canmount	off		canmount	on
 	xattr		on		xattr		off
 	compression	gzip		compression	gzip-$((RANDOM%9 + 1))
-	copies		$((RANDOM%3 + 1))
+	copies		$((RANDOM%3 + 1))		compression zstd
+	compression	zstd-$((RANDOM%9 + 1))		compression zstd-fast
+	compression	zstd-fast-$((RANDOM%9 + 1))
 )
 else
 #	property	value		property	value


### PR DESCRIPTION
- adds zstd to history_002_pos.ksh
- adds random levels of zstd to history_002_pos.ksh
- adds zstd-fast to history_002_pos.ksh
- adds random levels of zstd-fast to history_002_pos.ksh

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>

i've choosen to add some random levels here (but ofc not all) because this is an extremely fast test anyway, also decided to add zstd-fast too, same reason(s) as above.

It think this is a great script to make sure the zstd-fast references work too.